### PR TITLE
Feat: 날씨 조회 기능 구현

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,16 +1,17 @@
-import express, { Request, Response } from 'express';
-import cors from 'cors';
-import rateLimit from 'express-rate-limit';
-import Sentry from '@sentry/node';
-import userRouter from './routes/user.route';
-import pingRouter from './routes/ping.route';
-import taskRouter from './routes/task.route';
-import searchRouter from './routes/search.route';
-import joinRouter from './routes/join.route';
-import { errorHandler } from './middlewares/errorHandler';
-import { notFoundHandler } from './middlewares/notFoundHandler';
-import morgan from 'morgan';
-import logger from './utils/logger';
+import express, { Request, Response } from "express";
+import cors from "cors";
+import rateLimit from "express-rate-limit";
+import Sentry from "@sentry/node";
+import userRouter from "./routes/user.route";
+import pingRouter from "./routes/ping.route";
+import taskRouter from "./routes/task.route";
+import searchRouter from "./routes/search.route";
+import joinRouter from "./routes/join.route";
+import weatherRouter from "./routes/weather.route";
+import { errorHandler } from "./middlewares/errorHandler";
+import { notFoundHandler } from "./middlewares/notFoundHandler";
+import morgan from "morgan";
+import logger from "./utils/logger";
 
 // API 요청 제한 수치 설정용 상수
 // 요청 제한 기준 시간, 요청 제한 횟수 설정
@@ -21,12 +22,10 @@ const RATE_LIMIT_MAX_CALLS = 30;
 const app = express();
 
 // CORS 설정, 로컬 개발 클라이언트(개발 도중에만 유효) 및 프론트 배포 URL (예정) 에서 오는 요청을 허용
-const allowedOrigins = [
-    'http://localhost:3000',
-    'https://ttolgaebi.com',
-];
+const allowedOrigins = ["http://localhost:3000", "https://ttolgaebi.com"];
 
-app.use(cors({
+app.use(
+  cors({
     origin: (origin, callback) => {
       if (!origin) {
         return callback(null, false); // CORS 정책 위반 시 그냥 요청 거부
@@ -38,59 +37,67 @@ app.use(cors({
       }
     },
     credentials: true,
-}));
+  })
+);
 
 // 배포 환경에서 API 요청 제한 기능 사용을 위한 설정
 // 실제 IP 주소는 Proxy 서버보다 1단계 뒤에 있음을 SET
-app.set('trust proxy', 1);
+app.set("trust proxy", 1);
 
 // 에러 로깅 기능
 // 응답 시간 계산 미들웨어
 app.use((req, res, next) => {
-    const start = process.hrtime();
-  
-    const originalWriteHead = res.writeHead.bind(res);
-    res.writeHead = function (statusCode: number, reasonPhrase?: string | any, headers?: any): Response {
-      const elapsed = process.hrtime(start);
-      const ms = elapsed[0] * 1000 + elapsed[1] / 1e6;
-      res.setHeader('X-Response-Time', ms.toFixed(3));
-  
-      // 타입 명확히 지정하고 호출
-      if (typeof reasonPhrase === 'string') {
-        return originalWriteHead(statusCode, reasonPhrase, headers);
-      } else {
-        return originalWriteHead(statusCode, reasonPhrase);
-      }
-    } as any; // (타입 오류 없애기 위해 최종적으로 any로 강제 변환)
-  
-    next();
+  const start = process.hrtime();
+
+  const originalWriteHead = res.writeHead.bind(res);
+  res.writeHead = function (
+    statusCode: number,
+    reasonPhrase?: string | any,
+    headers?: any
+  ): Response {
+    const elapsed = process.hrtime(start);
+    const ms = elapsed[0] * 1000 + elapsed[1] / 1e6;
+    res.setHeader("X-Response-Time", ms.toFixed(3));
+
+    // 타입 명확히 지정하고 호출
+    if (typeof reasonPhrase === "string") {
+      return originalWriteHead(statusCode, reasonPhrase, headers);
+    } else {
+      return originalWriteHead(statusCode, reasonPhrase);
+    }
+  } as any; // (타입 오류 없애기 위해 최종적으로 any로 강제 변환)
+
+  next();
 });
 
 // morgan 커스텀 토큰: JSON 포맷으로 요청 정보 + 응답 시간 기록
-morgan.token('json', (req, res) => {
-    const request = req as Request;
-    const response = res as Response;
-  
-    return JSON.stringify({
-      method: request.method,
-      url: request.originalUrl,
-      status: response.statusCode,
-      ip: request.ip,
-      userAgent: request.headers['user-agent'],
-      responseTime: res.getHeader('X-Response-Time') || null,
-      timestamp: new Date().toISOString(),
-    });
+morgan.token("json", (req, res) => {
+  const request = req as Request;
+  const response = res as Response;
+
+  return JSON.stringify({
+    method: request.method,
+    url: request.originalUrl,
+    status: response.statusCode,
+    ip: request.ip,
+    userAgent: request.headers["user-agent"],
+    responseTime: res.getHeader("X-Response-Time") || null,
+    timestamp: new Date().toISOString(),
+  });
 });
-  
+
 // morgan으로 모든 요청 로깅
-app.use(morgan(':json', {
+app.use(
+  morgan(":json", {
     stream: {
       write: (message: string) => {
         const log = JSON.parse(message);
-  
+
         // 항상 combined 기록
-        logger.info(log.message || `${log.method} ${log.url}`, log, { onlyCombined: true });
-  
+        logger.info(log.message || `${log.method} ${log.url}`, log, {
+          onlyCombined: true,
+        });
+
         // 에러 또는 성공 정확히 분기
         if (log.status >= 400) {
           logger.error(log.message || `${log.method} ${log.url}`, log); // 4xx, 5xx
@@ -99,57 +106,82 @@ app.use(morgan(':json', {
         }
       },
     },
-}));
+  })
+);
 
 // JSON 모듈 사용 설정 (절대 손대지 말 것!)
 app.use(express.json());
 
 // API 요청 제한 기능 설정 및 모듈 호출
 const limiter = rateLimit({
-    windowMs: RATE_LIMIT_WINDOW_MS, // 요청 제한 초기화 시간
-    max: RATE_LIMIT_MAX_CALLS, // 분당 요청 제한 수치
-    message: `해당 IP로부터 분당 ${RATE_LIMIT_MAX_CALLS}회 이상의 요청이 감지되었습니다. ${RATE_LIMIT_WINDOW_MS / 1000 / 60}분 뒤에 다시 시도해주세요.`,
-    standardHeaders: true,
-    legacyHeaders: false,
+  windowMs: RATE_LIMIT_WINDOW_MS, // 요청 제한 초기화 시간
+  max: RATE_LIMIT_MAX_CALLS, // 분당 요청 제한 수치
+  message: `해당 IP로부터 분당 ${RATE_LIMIT_MAX_CALLS}회 이상의 요청이 감지되었습니다. ${RATE_LIMIT_WINDOW_MS / 1000 / 60}분 뒤에 다시 시도해주세요.`,
+  standardHeaders: true,
+  legacyHeaders: false,
 });
 app.use(limiter);
 
 // 민감 경로 보호 미들웨어
 app.use((req, res, next) => {
-    const forbiddenPaths = [
-      '/.env', '/.git', '/config.json', '/phpmyadmin',
-      '/phpunit', '/vendor', '/lib', '/laravel', '/public', '/admin',
-      '/cms', '/crm', '/workspace', '/tests', '/test', '/demo',
-      '/panel', '/apps', '/app', '/tmp', '/storage', '/backup', '/logs', '/web', '/system'
-    ];
-    const requestPath = req.path.toLowerCase();
-    if (forbiddenPaths.some(forbidden => requestPath.startsWith(forbidden))) {
-      logger.warn(`[보안경고] 민감 경로 접근 시도: ${req.path}`);
-      res.status(403).send('Forbidden');
-      return;
-    }
-    next();
+  const forbiddenPaths = [
+    "/.env",
+    "/.git",
+    "/config.json",
+    "/phpmyadmin",
+    "/phpunit",
+    "/vendor",
+    "/lib",
+    "/laravel",
+    "/public",
+    "/admin",
+    "/cms",
+    "/crm",
+    "/workspace",
+    "/tests",
+    "/test",
+    "/demo",
+    "/panel",
+    "/apps",
+    "/app",
+    "/tmp",
+    "/storage",
+    "/backup",
+    "/logs",
+    "/web",
+    "/system",
+  ];
+  const requestPath = req.path.toLowerCase();
+  if (forbiddenPaths.some((forbidden) => requestPath.startsWith(forbidden))) {
+    logger.warn(`[보안경고] 민감 경로 접근 시도: ${req.path}`);
+    res.status(403).send("Forbidden");
+    return;
+  }
+  next();
 });
-  
+
 // favicon.ico 요청 무시 (불필요한 에러 방지)
-app.get('/favicon.ico', (req, res): void => {
-    res.status(204).end();
+app.get("/favicon.ico", (req, res): void => {
+  res.status(204).end();
 });
 
 // 테스트 API Router
-app.use('/api/ping', pingRouter);
+app.use("/api/ping", pingRouter);
 
 // 회원 API Router
-app.use('/api/users', userRouter);
+app.use("/api/users", userRouter);
 
 // 일정 API Router
 app.use("/api/tasks", taskRouter);
 
 // 네이버 장소 검색 API Router
-app.use('/api/search', searchRouter);
+app.use("/api/search", searchRouter);
 
 // 회원가입 API Router
-app.use('/api/join', joinRouter);
+app.use("/api/join", joinRouter);
+
+// 날씨 API Router
+app.use("/api/weather", weatherRouter);
 
 // Sentry 에러 핸들러 등록 (라우터 뒤에, 에러 핸들러 앞에 위치해야 함)
 Sentry.setupExpressErrorHandler(app);

--- a/src/controllers/weather.controller.ts
+++ b/src/controllers/weather.controller.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from "express";
+import { weatherService } from "../services/weather.service";
+import { airQualityService } from "../services/airQuality.service";
+
+export const weatherController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  try {
+    const latParam = req.query.lat as string;
+    const lonParam = req.query.lon as string;
+    const lat = parseFloat(latParam);
+    const lon = parseFloat(lonParam);
+
+    if (
+      isNaN(lat) ||
+      isNaN(lon) ||
+      lat < -90 ||
+      lat > 90 ||
+      lon < -180 ||
+      lon > 180
+    ) {
+      res.status(400).json({
+        success: false,
+        message: "정확한 위도와 경도를 모두 입력해주세요.",
+      });
+      return;
+    }
+
+    const weatherData = await weatherService(lat, lon);
+    const airQualityData = await airQualityService(lat, lon);
+
+    const currentWithAirQuality = {
+      ...weatherData.current,
+      pm10: airQualityData.current.pm10,
+      pm2_5: airQualityData.current.pm2_5,
+    };
+
+    res.status(200).json({
+      success: true,
+      location: weatherData.location,
+      current: currentWithAirQuality,
+      hourly: weatherData.hourly,
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/routes/weather.route.ts
+++ b/src/routes/weather.route.ts
@@ -1,0 +1,9 @@
+import express from "express";
+import { weatherController } from "../controllers/weather.controller";
+
+const router = express.Router();
+
+// 날씨 조회
+router.get("/", weatherController);
+
+export default router;

--- a/src/services/airQuality.service.ts
+++ b/src/services/airQuality.service.ts
@@ -1,0 +1,68 @@
+import axios from "axios";
+import { errorResponse } from "../utils/errorResponse";
+import { ERROR_CODES } from "../constants/errorCodes";
+
+interface AirQualityCurrent {
+  time: string;
+  pm10: number;
+  pm2_5: number;
+}
+
+interface AirQualityResponse {
+  current: AirQualityCurrent;
+}
+
+function formatLocalHour(date: Date): string {
+  const Y = date.getFullYear();
+  const M = String(date.getMonth() + 1).padStart(2, "0");
+  const D = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  return `${Y}-${M}-${D}T${h}:00`;
+}
+
+export const airQualityService = async (
+  latitude: number,
+  longitude: number
+): Promise<AirQualityResponse> => {
+  try {
+    const now = new Date();
+    now.setMinutes(0, 0, 0);
+    const currentHour = formatLocalHour(now);
+
+    const url = "https://air-quality-api.open-meteo.com/v1/air-quality";
+    const params = {
+      latitude,
+      longitude,
+      hourly: "pm10,pm2_5",
+      timezone: "Asia/Seoul",
+    };
+    const { data } = await axios.get(url, { params });
+    const { hourly } = data;
+
+    const idx = hourly.time.findIndex((t: string) => t === currentHour);
+    if (idx === -1) {
+      const { status, body } = errorResponse(
+        ERROR_CODES.NOT_FOUND,
+        "현재 시각에 해당하는 hourly 대기질 데이터가 없습니다."
+      );
+      throw { ...body, status };
+    }
+
+    const current: AirQualityCurrent = {
+      time: hourly.time[idx],
+      pm10: hourly.pm10[idx],
+      pm2_5: hourly.pm2_5[idx],
+    };
+    return { current };
+  } catch (err: any) {
+    if (err.status && err.code) {
+      throw err;
+    }
+    const { status, body } = errorResponse(
+      ERROR_CODES.INTERNAL,
+      "대기질 데이터를 가져오는 중 오류가 발생했습니다.",
+      { originalError: err.message }
+    );
+    throw { ...body, status };
+  }
+};

--- a/src/services/weather.service.ts
+++ b/src/services/weather.service.ts
@@ -1,0 +1,115 @@
+import axios from "axios";
+import { errorResponse } from "../utils/errorResponse";
+import { ERROR_CODES } from "../constants/errorCodes";
+
+export interface WeatherLocation {
+  latitude: number;
+  longitude: number;
+  timezone: string;
+}
+
+export interface WeatherCurrent {
+  time: string;
+  temperature: number;
+  weathercode: number;
+  humidity: number;
+  windspeed: number;
+  pressure: number;
+  uv_index: number;
+}
+
+export interface WeatherHourly {
+  time: string;
+  temperature: number;
+  precipitation: number;
+  weathercode: number;
+}
+
+export interface WeatherResponse {
+  location: WeatherLocation;
+  current: WeatherCurrent;
+  hourly: WeatherHourly[];
+}
+
+function formatLocalHour(date: Date): string {
+  const Y = date.getFullYear();
+  const M = String(date.getMonth() + 1).padStart(2, "0");
+  const D = String(date.getDate()).padStart(2, "0");
+  const h = String(date.getHours()).padStart(2, "0");
+  return `${Y}-${M}-${D}T${h}:00`;
+}
+
+export const weatherService = async (
+  latitude: number,
+  longitude: number
+): Promise<WeatherResponse> => {
+  try {
+    const now = new Date();
+    now.setMinutes(0, 0, 0);
+    const currentHour = formatLocalHour(now);
+
+    const url = "https://api.open-meteo.com/v1/forecast";
+    const params = {
+      latitude,
+      longitude,
+      current_weather: true,
+      hourly:
+        "temperature_2m,precipitation,weathercode,relativehumidity_2m,pressure_msl,uv_index",
+      timezone: "Asia/Seoul",
+    };
+
+    const { data } = await axios.get(url, {
+      params,
+      timeout: 5000,
+    });
+
+    const {
+      latitude: lat,
+      longitude: lon,
+      timezone,
+      current_weather,
+      hourly,
+    } = data;
+
+    const startIdx = hourly.time.findIndex((t: string) => t === currentHour);
+    if (startIdx === -1) {
+      const { status, body } = errorResponse(
+        ERROR_CODES.NOT_FOUND,
+        "현재 시각에 해당하는 hourly 날씨 데이터가 없습니다."
+      );
+      throw { ...body, status };
+    }
+
+    const hourlyData: WeatherHourly[] = hourly.time
+      .slice(startIdx, startIdx + 24)
+      .map((time: string, i: number) => ({
+        time,
+        temperature: hourly.temperature_2m[startIdx + i],
+        precipitation: hourly.precipitation[startIdx + i],
+        weathercode: hourly.weathercode[startIdx + i],
+      }));
+
+    const current: WeatherCurrent = {
+      time: current_weather.time,
+      temperature: current_weather.temperature,
+      weathercode: current_weather.weathercode,
+      humidity: hourly.relativehumidity_2m[startIdx],
+      windspeed: current_weather.windspeed,
+      pressure: hourly.pressure_msl[startIdx],
+      uv_index: hourly.uv_index[startIdx],
+    };
+
+    const location: WeatherLocation = { latitude, longitude, timezone };
+    return { location, current, hourly: hourlyData };
+  } catch (err: any) {
+    if (err.status && err.code) {
+      throw err;
+    }
+    const { status, body } = errorResponse(
+      ERROR_CODES.INTERNAL,
+      "날씨 데이터를 가져오는 중 오류가 발생했습니다.",
+      { originalError: err.message }
+    );
+    throw { ...body, status };
+  }
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] app.ts 파일에 weather API Router 추가
- [x] weather.route.ts 파일 생성
- [x] weather.controller.ts 파일 생성
- [x] weather.service.ts 파일 생성
- [x] airQuality.service.ts 파일 생성

## 💡 자세한 설명

1. Open-Meteo 사이트의 무료 API 서비스를 활용하여, FE에서 위도와 경도를 바탕으로 요청에 대한 날씨 응답을 주는 기능 구현
2. [weather.service.ts] FE에서 http://localhost:3000/api/weather?lat=37.57&lon=126.98 을 보낼 경우
Open-Meteo 서버는 요청한 좌표를 기준으로 가장 가까운 격자(grid) 데이터를 보내준다.
따라서, "latitude": 37.55, "longitude": 127, 을 돌려 받으나
FE에서 요청한 lat=37.57과 lon=126.98을 좌표 그대로 응답하도록 코드를 작성했다.
3. [weather.service.ts] Timeout 5000ms 을 추가하여 무한 로딩에 걸리지 않도록 추가하였다.
4. 미세먼지 및 초미세먼지는 Open-Meteo 사이트에서 다른 API로 요청해야 하기에 airQuality.service.ts 파일로 분리

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
